### PR TITLE
Task-54582: Close button does not work when call is finished #102

### DIFF
--- a/src/main/frontend/vue-app/components/ExitScreen.vue
+++ b/src/main/frontend/vue-app/components/ExitScreen.vue
@@ -11,17 +11,19 @@ export default {
   name: "ExitScreen" ,
   computed:{
     isMobile() {
-      return this.$vuetify.breakpoint.name === "xs" || this.$vuetify.breakpoint.name === "sm";
+      return navigator.userAgentData && navigator.userAgentData.mobile || (navigator.userAgent && /mobi/i.test(navigator.userAgent.toLowerCase())) || false;
     },
   },
   methods:{
     closeWindow(){
-      window.close() ; 
+      (window.require(["SHARED/webConferencing"],function(webConferencing){
+        webConferencing.closeWindow();
+      }))();
     }
-  }
+  },
 };
 </script>
- <style lang="less" scoped>
+<style lang="less" scoped>
 #exit-screen {
   position: absolute;
   top: 0;

--- a/src/main/resources/public/js/call.js
+++ b/src/main/resources/public/js/call.js
@@ -236,7 +236,7 @@ require([
           app.initExitScreen();
         }
       }, 250);
-      window.close();
+      webConferencing.closeWindow();
     };
     
     var subscribeUser = function(userId) {
@@ -491,7 +491,6 @@ require([
       window.addEventListener("beforeunload", beforeunloadListener);
     };
   };
-
   const meetApp = new MeetApp();
   meetApp.init();
 });


### PR DESCRIPTION
ISSUE: closing the call from either jitsi's hang up button or the close button in the exit screen for mobiles doesn't work.
FIX: using the webConferencing object responsible of opening the call window to close it.

ISSUE: vuetify's breakpoint sometimes returns undefined
FIX: changed  the isMobile method to detect mobile device using the userAgent