### PR TITLE
Fix using language in Jitsi call window

### DIFF
--- a/src/main/frontend/vue-app/main.js
+++ b/src/main/frontend/vue-app/main.js
@@ -24,7 +24,7 @@ const vuetify = new Vuetify({
 const lang = window.eXo && eXo.env && eXo.env.portal && eXo.env.portal.language || "en";
 const localePortlet = "locale.jitsi";
 const resourceBundleName = "jitsi";
-const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/${localePortlet}.${resourceBundleName}-${lang}.json`;
+const url = `/portal/rest/i18n/bundle/${localePortlet}.${resourceBundleName}-${lang}.json`;
 
 export function init() {
   // getting locale ressources


### PR DESCRIPTION
When displaying Jitsi Call window, sometimes an error of type `eXo is not defined` is displayed and crashes the page. This fix will ensure to avoid such a case by using a static call for portal & rest.