### PR TITLE
TASK-56523: remove close button in jitsi call window for mobile (#30)

### DIFF
--- a/src/main/frontend/vue-app/components/ExitScreen.vue
+++ b/src/main/frontend/vue-app/components/ExitScreen.vue
@@ -2,23 +2,12 @@
   <v-app id="exit-screen" ref="exitscreen">
     <img src="/jitsi/images/logo.png " />
     <p>This call already finished. Now you can close this window.</p>
-    <v-btn v-if="isMobile" color="primary" @click="closeWindow">close</v-btn>
   </v-app>
 </template>
 
 <script>
 export default {
   name: "ExitScreen" ,
-  computed:{
-    isMobile() {
-      return this.$vuetify.breakpoint.name === "xs" || this.$vuetify.breakpoint.name === "sm";
-    },
-  },
-  methods:{
-    closeWindow(){
-      window.close() ; 
-    }
-  }
 };
 </script>
  <style lang="less" scoped>


### PR DESCRIPTION
Remove previously added close button in mobile device. In fact, this button has been removed because in some cases, the window can't be closed.

(cherry picked from commit 8d9fdb42961bb192f386f22a6063d4a3d7f33585)