### PR TITLE
TASK-57338: recording option is displayed for guests

### DIFF
--- a/src/main/resources/public/js/call.js
+++ b/src/main/resources/public/js/call.js
@@ -297,20 +297,24 @@ require([
           },
           interfaceConfigOverwrite: {
             TOOLBAR_BUTTONS: [
-              "microphone",
-              "chat",
-              "camera",
               "desktop",
-              "fullscreen",
-              "fodeviceselection",
+              "camera",
+              "chat",
               "hangup",
+              "fullscreen",
+              "microphone",
+              "mute-everyone",
+              "mute-video-everyone",
+              "participants-pane",
               "profile",
-              "sharedvideo",
+              "raisehand",
               "settings",
-              "videoquality",
+              "security",
+              "select-background",
               "tileview",
-              "videobackgroundblur",
-              "mute-everyone"
+              "toggle-camera",
+              "videoquality",
+              "closedcaptions"
             ],
             JITSI_WATERMARK_LINK: "",
             SETTINGS_SECTIONS: settings


### PR DESCRIPTION
Prior to this change, recording option is displayed for guests because the toolbar options already overwritten in jitsi web docker image by the TOOLBAR_BUTTONS property which adds the recording option without checking if the user is a guest or not.
This PR should add the needed toolbar options in jisti-call to fix this issue after re-building the exo/jitsi-web and removing the TOOLBAR_BUTTONS options from docker configs