### PR TITLE
TASK-57495: Restore share video and share audio options in jitsi call

### DIFF
--- a/src/main/resources/public/js/call.js
+++ b/src/main/resources/public/js/call.js
@@ -314,7 +314,9 @@ require([
               "tileview",
               "toggle-camera",
               "videoquality",
-              "closedcaptions"
+              "closedcaptions",
+              "sharedvideo",
+              "shareaudio"
             ],
             JITSI_WATERMARK_LINK: "",
             SETTINGS_SECTIONS: settings


### PR DESCRIPTION
Prior to this change, share video and share audio are no longer available in jitsi-call because they were removed during last updates and config adjustments.
This PR should restore the removed share video option and add a share audio option.