### PR TITLE
fix: add logging when failed to close window - EXO-60257

### DIFF
--- a/src/main/resources/public/js/call.js
+++ b/src/main/resources/public/js/call.js
@@ -233,6 +233,7 @@ require([
       setTimeout(() => {
         if (!window.closed) {
           // If not already closed we show the exit message to the user
+          console.log('[Jitsi] error: Scripts may not close windows that were not opened by script.');
           app.initExitScreen();
         }
       }, 250);


### PR DESCRIPTION
Jitsi calls opened by direct links does not get closed at the end of a meeting, in contrary to calls opened by Call buttons because browser does not let the script close that window (Browser security)
To be able to catch JS errors from browser and especially when the Call window could not be closed by Jitsi JS script, we added this log to handle it by Mobile applications and close the Call window. It will be used to notify mobile application when the call window won't be closed.