### PR TITLE
fix: upgrade to use JDK17 as compiler target - EXO-58815 - Meeds-io/MIPs#26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
-ARG JAR_FILE=target/jitsi-call-0.0.1-SNAPSHOT.jar
-COPY ${JAR_FILE} jitsi-call-0.0.1-SNAPSHOT.jar
-ENTRYPOINT ["java","-jar", "/jitsi-call-0.0.1-SNAPSHOT.jar"]
+FROM exoplatform/jdk:openjdk-17-ubuntu-2004
+ARG JAR_FILE=target/jitsi-call.jar
+COPY ${JAR_FILE} /jitsi-call.jar
+ENTRYPOINT ["java", "-jar", "/jitsi-call.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <org.exoplatform.depmgt.version>21.x-security-fix-SNAPSHOT</org.exoplatform.depmgt.version>
-    <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
+    <spring-boot.version>2.7.6</spring-boot.version>
 
     <!-- Sonar properties -->
     <sonar.organization>exoplatform</sonar.organization>
@@ -85,6 +85,7 @@
   </dependencies>
 
   <build>
+    <finalName>${project.artifactId}</finalName>
     <resources>
       <resource>
         <directory>${project.basedir}/src/main/resources</directory>


### PR DESCRIPTION
This fix upgrades the spring boot version to make the project build with compiler target as 17 (Java version)