### PR TITLE
fix: Jitsi blue button generated invitation link isn't expected - EXO-71063

### DIFF
--- a/src/main/resources/public/js/call.js
+++ b/src/main/resources/public/js/call.js
@@ -344,10 +344,11 @@ require([
           });
         });
         api.addEventListener("participantRoleChanged", event => {
-          const inviteLink = provider.getInviteLink(call);
-          if (!isGuest) {
-            app.initCallLink(inviteLink);
-          }
+          provider.getInviteLink(call).then((inviteLink) => {
+            if (!isGuest) {
+              app.initCallLink(inviteLink);
+            }
+          });
           api.executeCommand("displayName", name);
           // For recording feature
           if (event.role === "moderator") {


### PR DESCRIPTION
Before this fix, the invite button during a call contains [Object object]? ... instead of the correct url This is due to calling a promise instead of getting the real link This commit update the call to correctly read the promise