### PR TITLE
fix : Add button more in settings menu - EXO-67973

### DIFF
--- a/src/main/resources/public/js/call.js
+++ b/src/main/resources/public/js/call.js
@@ -277,7 +277,7 @@ require([
         var roomTitle = getRoomTitle(call);
         var tabTitle = getTabTitle(call, userinfo.id);
         window.document.title = tabTitle;
-        var settings = ["devices", "language", "moderator"];
+        var settings = ["devices", "language", "moderator", "more"];
         if (isGuest) {
           settings.push("profile");
         }


### PR DESCRIPTION
Before this fix, in the settings menu the button more/General is not present. So it is not possible to unhide my video for example, as this option is into this menu

This commit configure the settings menu to have the "more" entry displayed