### PR TITLE
fix: js error in console due to wrong path for a css - EXO-73780

### DIFF
--- a/src/main/frontend/vue-app/components/InvitePopup.vue
+++ b/src/main/frontend/vue-app/components/InvitePopup.vue
@@ -62,7 +62,7 @@ export default {
       const link = iframe.contentWindow.document.createElement("link");
       link.rel = "stylesheet";
       link.type = "text/css";
-      link.href = "/eXoSkin/skin/css/vuetify/vuetify-all.css";
+      link.href = "/platform-ui/skin/css/vuetify-all.css";
       iframe.contentWindow.document.getElementsByTagName("HEAD")[0].appendChild(link);
       elementAutoHide.firstChild.prepend(icon);
     }

--- a/src/main/resources/templates/call.html
+++ b/src/main/resources/templates/call.html
@@ -9,7 +9,7 @@
 <link as="image" rel="preload" href="../images/logo.png" type="image/png">
 <!-- <link href="https://cdn.jsdelivr.net/npm/@mdi/font@5.x/css/materialdesignicons.min.css" rel="stylesheet"> -->
 <link href="/eXoSkin/skin/css/Core.css" rel="stylesheet">
-<link href="/eXoSkin/skin/css/vuetify/vuetify-all.css" rel="stylesheet">
+<link href="/platform-ui/skin/css/vuetify-all.css" rel="stylesheet">
 <script id="jitsi-api" th:src="${appUrl} + '/external_api.js'"></script>
 <script type="text/javascript" src="../js/common.js"></script>
 <script type="text/javascript" data-main="call" src="../js/require.js"></script>


### PR DESCRIPTION
Before this fix, the jitsi-call component try to load vuetify-all.css in eXoSkin module instead of platform-ui This commit fixes the css path