### PR TITLE
fix: single copy link button and visible copy confirmation EXO-65800

### DIFF
--- a/src/main/frontend/vue-app/components/InvitePopup.vue
+++ b/src/main/frontend/vue-app/components/InvitePopup.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     id="invite-popup"
+    :class="{ copied: copied }"
     class="invite-copy-link">
     <input
       id="inputURL"
@@ -14,19 +15,37 @@
       :title="hoverMsg"
       :aria-label="hoverMsg"
       type="button"
-      @click="displayMessage">
+      @click="copyLink">
       <svg
+        class="invite-copy-link__copy"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
         aria-hidden="true"
         focusable="false">
         <path d="M19 21H8V7h11v14zm0-16H8a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2zM16 1H4a2 2 0 0 0-2 2v14h2V3h12V1z" />
       </svg>
+      <svg
+        class="invite-copy-link__done"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        focusable="false">
+        <path d="M21 7L9 19l-5.5-5.5 1.41-1.41L9 16.17 19.59 5.59 21 7z" />
+      </svg>
     </button>
+    <span
+      class="invite-copy-link__feedback"
+      role="status">{{ textLink }}</span>
   </div>
 </template>
 
 <script>
+/** Id of the stylesheet injected in the Jitsi iframe, to inject it only once. */
+const COPY_LINK_STYLE_ID = "invite-popup-style";
+
+/** How long the copy confirmation stays displayed, in ms. */
+const COPIED_FEEDBACK_DELAY = 3000;
+
 // Styles of the copy link button, injected in the Jitsi iframe document since the
 // button is moved there and stylesheets of the parent document do not apply to it.
 const COPY_LINK_STYLE = `
@@ -76,6 +95,30 @@ const COPY_LINK_STYLE = `
     fill: currentColor;
     pointer-events: none;
   }
+  #invite-popup .invite-copy-link__copy {
+    display: block;
+  }
+  #invite-popup .invite-copy-link__done,
+  #invite-popup .invite-copy-link__feedback {
+    display: none;
+  }
+  #invite-popup.copied .invite-copy-link__copy {
+    display: none;
+  }
+  #invite-popup.copied .invite-copy-link__done {
+    display: block;
+  }
+  #invite-popup.copied .invite-copy-link__feedback {
+    display: inline-block;
+  }
+  #invite-popup .invite-copy-link__feedback {
+    margin-right: 8px;
+    color: #fff;
+    font-family: Helvetica, Arial, sans-serif;
+    font-size: 13px;
+    line-height: 1;
+    white-space: nowrap;
+  }
 `;
 
 export default {
@@ -91,14 +134,9 @@ export default {
     return {
       textLink: "Link copied to clipboard",
       hoverMsg: "Copy meeting link to copyboard",
-      type:"",
+      copied: false,
+      copiedTimeout: null,
     };
-  },
-
-  computed: {
-    textLinkMsg(){
-      return this.textLink;
-    }
   },
 
   mounted(){
@@ -108,19 +146,51 @@ export default {
     if (!elementAutoHide || !elementAutoHide.firstChild) {
       return;
     }
-    const style = frameDocument.createElement("style");
-    style.type = "text/css";
-    style.textContent = COPY_LINK_STYLE;
-    frameDocument.getElementsByTagName("HEAD")[0].appendChild(style);
+    if (!frameDocument.getElementById(COPY_LINK_STYLE_ID)) {
+      const style = frameDocument.createElement("style");
+      style.id = COPY_LINK_STYLE_ID;
+      style.type = "text/css";
+      style.textContent = COPY_LINK_STYLE;
+      frameDocument.getElementsByTagName("HEAD")[0].appendChild(style);
+    }
+    const previous = frameDocument.getElementById("invite-popup");
+    if (previous && previous !== this.$el) {
+      previous.remove();
+    }
     elementAutoHide.firstChild.prepend(this.$el);
   },
 
+  beforeDestroy() {
+    if (this.copiedTimeout) {
+      clearTimeout(this.copiedTimeout);
+    }
+  },
+
   methods: {
-    displayMessage() {
-      this.$root.$emit("alert-message", this.textLinkMsg, "success");
+    copyLink() {
+      this.showCopiedFeedback();
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(this.url).catch(() => this.copyWithSelection());
+      } else {
+        this.copyWithSelection();
+      }
+    },
+
+    copyWithSelection() {
       const input = this.$refs.copyinput;
       input.select();
       input.ownerDocument.execCommand("copy");
+    },
+
+    showCopiedFeedback() {
+      this.copied = true;
+      if (this.copiedTimeout) {
+        clearTimeout(this.copiedTimeout);
+      }
+      this.copiedTimeout = setTimeout(() => {
+        this.copied = false;
+        this.copiedTimeout = null;
+      }, COPIED_FEEDBACK_DELAY);
     }
   }
 };


### PR DESCRIPTION
app.initCallLink() is called on every participantRoleChanged event, so the component is mounted several times per call: the button injection is now idempotent and the stylesheet is injected only once. The copy confirmation is displayed in the Jitsi header next to the button the icon turns into a check mark and the message is shown for 3s since atoast rendered in the call page would be hidden behind the Jitsi iframe. The copy uses the clipboard API when available, with the execCommand selection as a fallback.